### PR TITLE
✨ Add a custom elm-ui element to a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * ✅ Beta build features making sense
 * ✅ Try out `elm-ui`
 * ✅ embed arbitrary HTML
-  * 1. A page type can be any elm that renders (or not) the markdown of the matching content page
+  * 1. ✅ A page type can be any elm that renders (or not) the markdown of the matching content page
   * 2. The markdown rendered can be extended to accept custom HTML tags
 * ✅ Try out beta template types
 * Can I embed arbitrary JS within the page (bundled unity)
@@ -17,6 +17,7 @@
 
 ### Questions
 * Is `elm-pages` a suitable replacement for jekyll?
+  * [compiler + signature > docs example PR](https://github.com/shamshirz/elm-pages-starter-beta/pull/2)
 * Would that be worth the effort?
 * ✅ Is `elm-pages` a suitable option for personal small projects?
  * > Yes

--- a/README.md
+++ b/README.md
@@ -7,13 +7,24 @@
 * ✅ Timebox
 * ✅ Try out [Cloudinary for hosting images](https://cloudinary.com/)
 * ✅ Beta build features making sense
-* 🏅 embed arbitrary HTML
-* 🏅 Try out beta template types
-* Try out `elm-ui`
+* ✅ Try out `elm-ui`
+* ✅ embed arbitrary HTML
+  * 1. A page type can be any elm that renders (or not) the markdown of the matching content page
+  * 2. The markdown rendered can be extended to accept custom HTML tags
+* ✅ Try out beta template types
+* Can I embed arbitrary JS within the page (bundled unity)
+* Test static requests (load Spotify data on deploy vs. real time)
+
+### Questions
 * Is `elm-pages` a suitable replacement for jekyll?
- * Would that be worth the effort?
-* Is `elm-pages` a suitable option for personal small projects?
- * I think so
+* Would that be worth the effort?
+* ✅ Is `elm-pages` a suitable option for personal small projects?
+ * > Yes
+
+
+### If the project continues
+* CI - lint, elm-review, elm-test
+* Give feedback to Dillon
 
 
 ## Tips
@@ -24,7 +35,7 @@
 ### How
 I cloned DKs repo and checked out his [Template Modules branch](https://github.com/dillonkearns/elm-pages-starter/tree/template-modules)
 
-### Example
+### Getting Started Example
 Started a new page `test.md` and followed the compiler
 
 * frontmatter error on `published: "2020-12-30"` needed quotes around date
@@ -40,7 +51,7 @@ Started a new page `test.md` and followed the compiler
   * `<BOX>` example and [this article on the elm markdown rendered](https://elm-pages.com/blog/extensible-markdown-parsing-in-elm)
 
 
-### Details
+### Resources
 * [Beta Changes](https://github.com/dillonkearns/elm-pages/blob/master/docs/7.0.0-elm-package-upgrade-guide.md#2---beta-build-command)
 * https://github.com/dillonkearns/elm-pages/issues/151
 * [Remove Bundling from build](https://github.com/dillonkearns/elm-pages/issues/148)

--- a/content/blog/noContent.md
+++ b/content/blog/noContent.md
@@ -1,0 +1,11 @@
+---
+type: all-elm
+author: "Aaron Votre"
+title: An all elm page
+description: This page doesn't expect any markdown
+image: v1609635308/simple-ag.png
+published: "2020-12-30"
+---
+
+Anything here will not show up because the view method doesn't use the rendered body!
+

--- a/content/blog/test.md
+++ b/content/blog/test.md
@@ -14,6 +14,7 @@ def fxn do
   %{alpha: 1}
   |> withBeta
   |> compute()
+  |> this_just_tests_code_block_highlighting()
 end
 ```
 

--- a/content/index.md
+++ b/content/index.md
@@ -1,14 +1,33 @@
 ---
-title: elm-pages-starter - a simple blog starter
+title: The new aaronvotre.com?
 type: page
 ---
 
-This is an example repo to get you up and running with `elm-pages`.
+With `elm-pages`, we can have different elm view code per type of page.
+Then, the markdown is rendered within the body of the page.
 
-The entrypoint file is `index.js`. That file imports `src/Main.elm`. The `content` folder is turned into your static pages. The rest is mostly determined by logic in the Elm code! Learn more with the resources below.
 
-## Learn more about `elm-pages`
+## How can we make custom elm UI?
+I don't think there is an easy way to embed it here, but I can easy tag it before or after the markdown
+See above 👆
 
-- Documentation site: https://elm-pages.com
-- [Elm Package docs](https://package.elm-lang.org/packages/dillonkearns/elm-pages/latest/)
-- [`elm-pages` blog](https://elm-pages.com/blog)
+## How can I embed an `Element msg` within the Markdown
+The demo site looks like Dillon make a custom renderer to accept custom HTML tags, example
+
+```markdown
+this is a paragraph
+<div>html is valid markdown</div>
+<CUSTOM param="x">and now this element can call to some elm code</CUSTOM>
+```
+
+## I want to embed arbitrary html into the markdown, how?
+html is valid markdown, but I want to embed basically an entire unity app. What will happen?
+Let's find out!
+<!--
+<ul>
+  <li>A</li>
+  <li>B</li>
+</ul>
+ -->
+
+Experiment did not work

--- a/src/Index.elm
+++ b/src/Index.elm
@@ -36,6 +36,9 @@ view posts =
 
                         TemplateType.BlogIndex _ ->
                             Nothing
+
+                        TemplateType.AllElm meta ->
+                            Just ( path, meta )
                 )
             |> List.sortWith postPublishDateDescending
             |> List.map postSummary

--- a/src/Template/AllElm.elm
+++ b/src/Template/AllElm.elm
@@ -1,0 +1,161 @@
+module Template.AllElm exposing (Model, Msg, template)
+
+import Data.Author as Author
+import Date exposing (Date)
+import Element exposing (Element, mouseDown, mouseOver, padding, text)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Font as Font
+import Element.Input as Input
+import Head
+import Index
+import Pages
+import Pages.ImagePath as ImagePath exposing (ImagePath)
+import Pages.PagePath exposing (PagePath)
+import Palette
+import Platform.Sub
+import Shared
+import Template exposing (StaticPayload, Template, TemplateWithState)
+import TemplateMetadata exposing (AllElm, BlogIndex)
+import TemplateType exposing (TemplateType)
+
+
+type alias Model =
+    Int
+
+
+type Msg
+    = Dec
+    | Inc
+
+
+type alias StaticData =
+    ()
+
+
+update : TemplateMetadata.AllElm -> Msg -> Model -> ( Model, Cmd Msg )
+update meta msg model =
+    case msg of
+        Dec ->
+            ( model - 1, Cmd.none )
+
+        Inc ->
+            ( model + 1, Cmd.none )
+
+
+template : TemplateWithState AllElm StaticData Model Msg
+template =
+    Template.noStaticData { head = head }
+        -- |> Template.buildNoState
+        |> Template.buildWithLocalState
+            { init = always ( 4, Cmd.none )
+            , update = update
+            , subscriptions = \meta key model -> Platform.Sub.none
+
+            -- , subscriptions : templateMetadata -> PagePath Pages.PathKey -> templateModel -> Sub templateMsg
+            , view = view
+            }
+
+
+head :
+    StaticPayload AllElm StaticData
+    -> List (Head.Tag Pages.PathKey)
+head { metadata } =
+    []
+
+
+view :
+    Int
+    -> List ( PagePath Pages.PathKey, TemplateType )
+    -> StaticPayload AllElm StaticData
+    -> Shared.RenderedBody
+    -> Shared.PageView Msg
+view model allMetadata static _ =
+    { title = static.metadata.title
+    , body =
+        [ Element.column [ Element.spacing 10 ]
+            [ Element.row [ Element.spacing 10 ]
+                [ Author.view [] static.metadata.author
+                , Element.column [ Element.spacing 10, Element.width Element.fill ]
+                    [ Element.paragraph [ Font.bold, Font.size 24 ]
+                        [ Element.text static.metadata.author.name
+                        ]
+                    , Element.paragraph [ Font.size 16 ]
+                        [ Element.text static.metadata.author.bio ]
+                    ]
+                ]
+            ]
+        , publishedDateView static.metadata |> Element.el [ Font.size 16, Font.color (Element.rgba255 0 0 0 0.6) ]
+        , Palette.blogHeading static.metadata.title
+        , articleImageView static.metadata.image
+        , incrementButton
+        , Element.text (String.fromInt model)
+        , decrementButton
+        ]
+    }
+
+
+publishedDateView : { a | published : Date } -> Element msg
+publishedDateView metadata =
+    Element.text
+        (metadata.published
+            |> Date.format "MMMM ddd, yyyy"
+        )
+
+
+articleImageView : ImagePath Pages.PathKey -> Element msg
+articleImageView articleImage =
+    Element.image [ Element.width Element.fill ]
+        { src = ImagePath.toString articleImage
+        , description = "Article cover photo"
+        }
+
+
+incrementButton : Element Msg
+incrementButton =
+    Input.button
+        [ padding 10
+        , Border.width 3
+        , Border.rounded 6
+        , Border.color Palette.color.primary
+        , Background.color Palette.color.primary
+        , Font.variant Font.smallCaps
+
+        -- The order of mouseDown/mouseOver can be significant when changing
+        -- the same attribute in both
+        , mouseDown
+            [ Background.color Palette.color.primary
+            , Border.color Palette.color.primary
+            , Font.color Palette.color.primary
+            ]
+        , mouseOver
+            [ Background.color Palette.color.primary
+            , Border.color Palette.color.primary
+            ]
+        ]
+        { onPress = Just Inc, label = text "+" }
+
+
+decrementButton : Element Msg
+decrementButton =
+    Input.button
+        [ padding 10
+        , Border.width 3
+        , Border.rounded 6
+        , Border.color Palette.color.primary
+        , Background.color Palette.color.primary
+        , Font.variant Font.smallCaps
+
+        -- The order of mouseDown/mouseOver can be significant when changing
+        -- the same attribute in both
+        , mouseDown
+            [ Background.color Palette.color.primary
+            , Border.color Palette.color.primary
+            , Font.color Palette.color.primary
+            ]
+        , mouseOver
+            [ Background.color Palette.color.primary
+            , Border.color Palette.color.primary
+            ]
+        ]
+        { onPress = Just Dec, label = text "-" }

--- a/src/Template/Page.elm
+++ b/src/Template/Page.elm
@@ -1,12 +1,18 @@
 module Template.Page exposing (Model, Msg, template)
 
 import Cloudinary
+import Element exposing (Element, mouseDown, mouseOver, padding, text)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Font as Font
+import Element.Input as Input
 import Head
 import Head.Seo as Seo
 import MimeType
 import Pages
 import Pages.ImagePath exposing (ImagePath)
 import Pages.PagePath exposing (PagePath)
+import Palette
 import Shared
 import Site
 import Template exposing (StaticPayload, Template)
@@ -60,9 +66,35 @@ view :
 view allMetadata static rendered =
     { title = static.metadata.title
     , body =
-        [ rendered
+        [ elmUiBayB
+        , rendered
         ]
     }
+
+
+elmUiBayB : Element msg
+elmUiBayB =
+    Input.button
+        [ padding 10
+        , Border.width 3
+        , Border.rounded 6
+        , Border.color Palette.color.primary
+        , Background.color Palette.color.primary
+        , Font.variant Font.smallCaps
+
+        -- The order of mouseDown/mouseOver can be significant when changing
+        -- the same attribute in both
+        , mouseDown
+            [ Background.color Palette.color.primary
+            , Border.color Palette.color.primary
+            , Font.color Palette.color.primary
+            ]
+        , mouseOver
+            [ Background.color Palette.color.primary
+            , Border.color Palette.color.primary
+            ]
+        ]
+        { onPress = Nothing, label = text "styled button" }
 
 
 cloudinaryIcon : ImagePath pathKey

--- a/src/TemplateMetadata.elm
+++ b/src/TemplateMetadata.elm
@@ -1,4 +1,4 @@
-module TemplateMetadata exposing (Article, BlogIndex, Page)
+module TemplateMetadata exposing (AllElm, Article, BlogIndex, Page)
 
 import Data.Author
 import Date exposing (Date)
@@ -22,3 +22,13 @@ type alias Article =
 
 type alias Page =
     { title : String }
+
+
+type alias AllElm =
+    { title : String
+    , description : String
+    , published : Date
+    , author : Data.Author.Author
+    , image : ImagePath Pages.PathKey
+    , draft : Bool
+    }

--- a/src/TemplateType.elm
+++ b/src/TemplateType.elm
@@ -10,7 +10,8 @@ import TemplateMetadata
 
 
 type TemplateType
-    = Page TemplateMetadata.Page
+    = AllElm TemplateMetadata.AllElm
+    | Page TemplateMetadata.Page
     | Article TemplateMetadata.Article
     | BlogIndex ()
 
@@ -52,6 +53,31 @@ decoder =
                                 |> Decode.map (Maybe.withDefault False)
                             )
                             |> Decode.map Article
+
+                    "all-elm" ->
+                        Decode.map6 TemplateMetadata.AllElm
+                            (Decode.field "title" Decode.string)
+                            (Decode.field "description" Decode.string)
+                            (Decode.field "published"
+                                (Decode.string
+                                    |> Decode.andThen
+                                        (\isoString ->
+                                            case Date.fromIsoString isoString of
+                                                Ok date ->
+                                                    Decode.succeed date
+
+                                                Err error ->
+                                                    Decode.fail error
+                                        )
+                                )
+                            )
+                            (Decode.field "author" Data.Author.decoder)
+                            (Decode.field "image" imageDecoder)
+                            (Decode.field "draft" Decode.bool
+                                |> Decode.maybe
+                                |> Decode.map (Maybe.withDefault False)
+                            )
+                            |> Decode.map AllElm
 
                     _ ->
                         Decode.fail ("Unexpected page type " ++ pageType)


### PR DESCRIPTION
Part way there! Weirdly couldn't add html directly, investigation needed, but made my first elm-ui element (completely copied it from alex korban)

## Elm-UI + local state!


https://user-images.githubusercontent.com/8139629/104966106-1ebfcd00-59ae-11eb-8cb1-28fbddbbe02d.mov


### Developers note
The last commit, to get a page with local state did not require me to read the docs (went by type signature alone) and took ~1hr to figure out. If this had been jekyll or any system that didn't involve a helpful compiler and type signatures, it could not have been done without a guide.